### PR TITLE
Adds option for status code

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,16 @@ module.exports = {
       name: 'externalUrl',
       label: 'URL',
       type: 'url'
+    },
+    {
+      name: 'statusCode',
+      label: 'What type of redirect is this?',
+      type: 'select',
+      def: '302',
+      choices: [
+        { label: 'Permanent', value: '301' },
+        { label: 'Temporary', value: '302' }
+      ]
     }
   ],
   removeFields: ['tags'],
@@ -80,7 +90,8 @@ module.exports = {
         'title',
         'urlType',
         '_newPage',
-        'externalUrl'
+        'externalUrl',
+        'statusCode'
       ]
     }
   ],
@@ -99,6 +110,7 @@ module.exports = {
 
     // Check to see if a redirect exists before sending user on their way
     self.expressMiddleware = function (req, res, next) {
+      var statusCode = parseInt(req.statusCode) || 302;
       var slug = req.url;
       return self.find(req, { slug: 'redirect-' + slug }, {
         title: 1,
@@ -117,7 +129,7 @@ module.exports = {
           if (result.urlType === 'internal' && result._newPage) {
             return req.res.redirect(result._newPage.slug);
           } else if (result.urlType === 'external' && result.externalUrl.length) {
-            return req.res.redirect(result.externalUrl);
+            return req.res.redirect(statusCode, result.externalUrl);
           }
         }
         return next();


### PR DESCRIPTION
I think there's some more to do here, but I wanted to put this up as a suggested enhancement. A client working with an SEO agency asked for all the redirects to be changed to 301s. Express' [`res.redirect`](https://expressjs.com/en/4x/api.html#res.redirect) defaults to 302, so this would allow them to make that change.

Thoughts before finishing this:
- It seems like 301 should be the default. That'd be a BC break which is no good. Therefore I'm thinking there should be an option set up here to allow the dev to make 301 the default instead on the project level. I'm not sure how to set that up exactly, but can dig deeper if ya'll agree.
- I don't think I have a second thought.