### PR TITLE
PRO-2504: middleware can now find redirects across locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.0
+In the presence of workflow and locale prefixes, a redirect created in a different locale will now work if the URL matches, falling back to the redirect target's locale even if the user's current or default locale is different.
+
 ## 2.3.2
 Corrects additional defects in query string handling that led to problems with the briefly released 2.3.1.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-redirects",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Allows admins to create redirects within an Apostrophe site",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

It turns out that enabling workflow for the redirects module does often make sense because it allows you to choose an internal page to link to in a particular locale. However, our redirect middleware was not able to find redirects in locales other than the default locale, unless the slug being redirected from coincidentally had the right prefix.

This logic has been overhauled to use raw mongodb queries to bypass the usual locale restriction, which also improves performance for this very frequently used code path.

## What are the specific steps to test this change?

In `apostrophe-enterprise-testbed`, a redirect created in the `fr` domain now works even if its trigger URL has no `/fr` prefix and the user was not previously in the `fr` domain.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [X] New feature
- [X] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
